### PR TITLE
Fixes for TCP connections and raw data collection.

### DIFF
--- a/SocketBundle/Socket/SocketBase.php
+++ b/SocketBundle/Socket/SocketBase.php
@@ -37,7 +37,17 @@ abstract class SocketBase
      * @access protected
      */
     protected $chunkLength = 1024;
-    
+
+    /**
+     * cleanMessages
+     *
+     * (default value: true)
+     *
+     * @var bool
+     * @access public
+     */
+    protected $cleanMessages = true;
+
      /**
      * setHost function.
      * 
@@ -61,7 +71,19 @@ abstract class SocketBase
     {
         $this->port = $port;   
     }
-    
+
+    /**
+    * setCleanMessages function.
+    *
+    * @access public
+    * @param bool $cleanMessages
+    * @return void
+    */
+    public function setCleanMessages($cleanMessages)
+    {
+       $this->cleanMessages = $cleanMessages;
+    }
+
     /**
      * getPort function.
      * 
@@ -83,7 +105,18 @@ abstract class SocketBase
     {
         return $this->host;
     }
-    
+
+    /**
+     * getCleanMessages function.
+     *
+     * @access public
+     * @return bool
+     */
+    public function getCleanMessages()
+    {
+        return $this->cleanMessages;
+    }
+
     /**
      * cleanMessage function.
      * 
@@ -93,7 +126,12 @@ abstract class SocketBase
      */
     protected function cleanMessage($message)
     {
-        return preg_replace('/^[\s\r\n]+|[\s\r\n]+$/', '', $message);
+        if ($this->cleanMessages) {
+            return preg_replace('/^[\s\r\n]+|[\s\r\n]+$/', '', $message);
+        }
+        else {
+            return $message;
+        }
     }
 
 }

--- a/SocketBundle/Socket/SocketServer.php
+++ b/SocketBundle/Socket/SocketServer.php
@@ -369,6 +369,9 @@ class SocketServer extends SocketBase
             }
             $this->logger->debug("Received information from a socket ". substr($input, 0, 35));
         }
+        else {
+            $this->close($stream);
+        }
     }
     
     /**

--- a/SocketBundle/Socket/SocketServer.php
+++ b/SocketBundle/Socket/SocketServer.php
@@ -358,7 +358,8 @@ class SocketServer extends SocketBase
             
             $evt->setMessage($input);
             
-            $data = $this->serializer->unserialize($input, $this->serializeFormat);
+            // $data = $this->serializer->unserialize($input, $this->serializeFormat);
+            $data = $input;
             
             $evt->setData($data);
             


### PR DESCRIPTION
I'm starting to use this bundle in a project for receiving data frames from SCADA devices. I think they're poorly designed and doesn't close TCP connections properly after a FIN is sent, leaving sockets in LAST_ACK and receiving 0 bytes in readMessages(). This is a fix for this problem.

Also, I had to remove a call to an undefined unserialize(). As I'm using plain bytes, this is OK for me.

Lastly, I've added optional cleaning of messages, as I need complete frames with some 0x0D endings in them.
